### PR TITLE
upgrade go-base dependency to use new cbor package

### DIFF
--- a/cli/alphabill/cmd/shard_node_run_test.go
+++ b/cli/alphabill/cmd/shard_node_run_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types/hex"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethrpc "github.com/ethereum/go-ethereum/rpc"
@@ -373,7 +374,7 @@ func makeSuccessfulPayment(t *testing.T, ctx context.Context, rpcClient *ethrpc.
 		NewOwnerPredicate: templates.AlwaysTrueBytes(),
 		TargetValue:       500,
 	}
-	attrBytes, err := types.Cbor.Marshal(attr)
+	attrBytes, err := cbor.Marshal(attr)
 	require.NoError(t, err)
 
 	tx := &types.TransactionOrder{
@@ -387,7 +388,7 @@ func makeSuccessfulPayment(t *testing.T, ctx context.Context, rpcClient *ethrpc.
 		},
 	}
 	require.NoError(t, tx.SetAuthProof(money.TransferAuthProof{}))
-	txBytes, err := types.Cbor.Marshal(tx)
+	txBytes, err := cbor.Marshal(tx)
 	require.NoError(t, err)
 
 	var res hex.Bytes
@@ -401,7 +402,7 @@ func makeFailingPayment(t *testing.T, ctx context.Context, rpcClient *ethrpc.Cli
 		NewOwnerPredicate: templates.AlwaysTrueBytes(),
 		TargetValue:       500,
 	}
-	attrBytes, err := types.Cbor.Marshal(attr)
+	attrBytes, err := cbor.Marshal(attr)
 	require.NoError(t, err)
 
 	tx := &types.TransactionOrder{
@@ -415,7 +416,7 @@ func makeFailingPayment(t *testing.T, ctx context.Context, rpcClient *ethrpc.Cli
 		},
 	}
 	require.NoError(t, tx.SetAuthProof(money.TransferAuthProof{}))
-	txBytes, err := types.Cbor.Marshal(tx)
+	txBytes, err := cbor.Marshal(tx)
 	require.NoError(t, err)
 
 	var res hex.Bytes
@@ -434,7 +435,7 @@ func sendTokensTx(t *testing.T, ctx context.Context, rpcClient *ethrpc.Client) {
 		TokenTypeOwnerPredicate:  templates.AlwaysTrueBytes(),
 		DataUpdatePredicate:      templates.AlwaysTrueBytes(),
 	}
-	attrBytes, err := types.Cbor.Marshal(attr)
+	attrBytes, err := cbor.Marshal(attr)
 	require.NoError(t, err)
 	tx := &types.TransactionOrder{
 		Version: 1,
@@ -447,7 +448,7 @@ func sendTokensTx(t *testing.T, ctx context.Context, rpcClient *ethrpc.Client) {
 		},
 	}
 	// require.NoError(t, tokens.GenerateUnitID(tx, types.ShardID{}, &pdr))
-	txBytes, err := types.Cbor.Marshal(tx)
+	txBytes, err := cbor.Marshal(tx)
 	require.NoError(t, err)
 	var res hex.Bytes
 	err = rpcClient.CallContext(ctx, &res, "state_sendTransaction", hexutil.Encode(txBytes))
@@ -457,7 +458,7 @@ func sendTokensTx(t *testing.T, ctx context.Context, rpcClient *ethrpc.Client) {
 	// failing case
 	var res2 hex.Bytes
 	tx.PartitionID = 0x01000000 // incorrect partition id
-	txBytes, err = types.Cbor.Marshal(tx)
+	txBytes, err = cbor.Marshal(tx)
 	require.NoError(t, err)
 	err = rpcClient.CallContext(ctx, &res2, "state_sendTransaction", hexutil.Encode(txBytes))
 	require.ErrorContains(t, err, "invalid transaction partition identifier")

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.24
 
 require (
 	github.com/ainvaltin/httpsrv v0.3.1
-	github.com/alphabill-org/alphabill-go-base v1.0.0-rc2.0.20250616134600-00f00435b2f9
+	github.com/alphabill-org/alphabill-go-base v1.0.0-rc2.0.20250617183208-7e1d46004770
 	github.com/ethereum/go-ethereum v1.14.11
-	github.com/fxamacker/cbor/v2 v2.7.0
+	github.com/fxamacker/cbor/v2 v2.8.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/ainvaltin/httpsrv v0.3.1 h1:E7Oq7hpmYUDFh7olry6MFQTQwXEdaqMMOrzrgGZxiPc=
 github.com/ainvaltin/httpsrv v0.3.1/go.mod h1:hsvXrOXgWiWfGSYUCRRBlBYKPwLM1WWzGuqhp8dEcDY=
-github.com/alphabill-org/alphabill-go-base v1.0.0-rc2.0.20250616134600-00f00435b2f9 h1:XtEAL3ThB6ME0KhSbAULGouzhafOGT0KM2JAhVl+eoA=
-github.com/alphabill-org/alphabill-go-base v1.0.0-rc2.0.20250616134600-00f00435b2f9/go.mod h1:TlO/XqmwE97ET0bUt4xGePkeSHHR2m2L/EXUepMXpl0=
+github.com/alphabill-org/alphabill-go-base v1.0.0-rc2.0.20250617183208-7e1d46004770 h1:pNSFWzJb53iJnrVRA04umRjDwkRYMQuviDZfrqKbJRI=
+github.com/alphabill-org/alphabill-go-base v1.0.0-rc2.0.20250617183208-7e1d46004770/go.mod h1:v/l66KCh40349xOiJgfILev95K3IbzpiU3VhFK3nxjM=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
@@ -97,8 +97,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
-github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
-github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
+github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
+github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=

--- a/keyvaluedb/boltdb/bolt_db.go
+++ b/keyvaluedb/boltdb/bolt_db.go
@@ -5,8 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/alphabill-org/alphabill-go-base/types"
-
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill/keyvaluedb"
 	bolt "go.etcd.io/bbolt"
 )
@@ -39,8 +38,8 @@ func New(dbFile string) (*BoltDB, error) {
 	s := &BoltDB{
 		db:      db,
 		bucket:  []byte(defaultBucket),
-		encoder: types.Cbor.Marshal,
-		decoder: types.Cbor.Unmarshal,
+		encoder: cbor.Marshal,
+		decoder: cbor.Unmarshal,
 	}
 	if err = s.createBuckets(); err != nil {
 		return nil, err

--- a/keyvaluedb/memorydb/memorydb.go
+++ b/keyvaluedb/memorydb/memorydb.go
@@ -4,8 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/alphabill-org/alphabill-go-base/types"
-
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill/keyvaluedb"
 )
 
@@ -28,8 +27,8 @@ type (
 func New() (*MemoryDB, error) {
 	return &MemoryDB{
 		db:      make(map[string][]byte),
-		encoder: types.Cbor.Marshal,
-		decoder: types.Cbor.Unmarshal,
+		encoder: cbor.Marshal,
+		decoder: cbor.Unmarshal,
 	}, nil
 }
 

--- a/network/cbor.go
+++ b/network/cbor.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/alphabill-org/alphabill-go-base/types"
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 )
 
 func serializeMsg(msg any) ([]byte, error) {
-	data, err := types.Cbor.Marshal(msg)
+	data, err := cbor.Marshal(msg)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling %T as CBOR: %w", msg, err)
 	}
@@ -32,7 +32,7 @@ func deserializeMsg(r io.Reader, msg any) error {
 	}
 
 	lengthInt64 := int64(length64) /* #nosec G115 its unlikely that value of length64 exceeds int64 max value */
-	if err := types.Cbor.Decode(io.LimitReader(src, lengthInt64), msg); err != nil {
+	if err := cbor.Decode(io.LimitReader(src, lengthInt64), msg); err != nil {
 		return fmt.Errorf("decoding message data: %w", err)
 	}
 

--- a/network/protocol/abdrc/ir_change_req.go
+++ b/network/protocol/abdrc/ir_change_req.go
@@ -3,6 +3,7 @@ package abdrc
 import (
 	"fmt"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/crypto"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill-go-base/types/hex"
@@ -68,5 +69,5 @@ func (x *IrChangeReqMsg) Verify(tb types.RootTrustBase) error {
 func (x *IrChangeReqMsg) bytes() ([]byte, error) {
 	xCopy := *x
 	xCopy.Signature = nil
-	return types.Cbor.Marshal(xCopy)
+	return cbor.Marshal(xCopy)
 }

--- a/network/protocol/abdrc/ir_change_req_test.go
+++ b/network/protocol/abdrc/ir_change_req_test.go
@@ -3,6 +3,7 @@ package abdrc
 import (
 	"testing"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/crypto"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	testsig "github.com/alphabill-org/alphabill/internal/testutils/sig"
@@ -231,7 +232,7 @@ func TestIrChangeReqMsg_bytes(t *testing.T) {
 	}
 	msgCopy := *msg
 	msgCopy.Signature = nil
-	expected, err := types.Cbor.Marshal(msgCopy)
+	expected, err := cbor.Marshal(msgCopy)
 	require.NoError(t, err)
 	msgBytes, err := msg.bytes()
 	require.NoError(t, err)

--- a/network/protocol/certification/block_certification_request.go
+++ b/network/protocol/certification/block_certification_request.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/crypto"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill-go-base/types/hex"
@@ -17,14 +18,14 @@ var (
 )
 
 type BlockCertificationRequest struct {
-	_              struct{}           `cbor:",toarray"`
-	PartitionID    types.PartitionID  `json:"partitionId"`
-	ShardID        types.ShardID      `json:"shardId"`
-	NodeID         string             `json:"nodeId"`
-	InputRecord    *types.InputRecord `json:"inputRecord"`
-	BlockSize      uint64             `json:"blockSize"`
-	StateSize      uint64             `json:"stateSize"`
-	Signature      hex.Bytes          `json:"signature"`
+	_           struct{}           `cbor:",toarray"`
+	PartitionID types.PartitionID  `json:"partitionId"`
+	ShardID     types.ShardID      `json:"shardId"`
+	NodeID      string             `json:"nodeId"`
+	InputRecord *types.InputRecord `json:"inputRecord"`
+	BlockSize   uint64             `json:"blockSize"`
+	StateSize   uint64             `json:"stateSize"`
+	Signature   hex.Bytes          `json:"signature"`
 }
 
 func (x *BlockCertificationRequest) IRRound() uint64 {
@@ -85,5 +86,5 @@ func (x *BlockCertificationRequest) Sign(signer crypto.Signer) error {
 
 func (x BlockCertificationRequest) Bytes() ([]byte, error) {
 	x.Signature = nil
-	return types.Cbor.Marshal(x)
+	return cbor.Marshal(x)
 }

--- a/network/protocol/certification/block_certification_request_test.go
+++ b/network/protocol/certification/block_certification_request_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	testsig "github.com/alphabill-org/alphabill/internal/testutils/sig"
 )
@@ -44,7 +45,7 @@ func Test_BlockCertificationRequest_IsValid(t *testing.T) {
 
 		bcr2 := *bcr
 		bcr2.Signature = nil
-		bs2, err := types.Cbor.Marshal(bcr2)
+		bs2, err := cbor.Marshal(bcr2)
 		require.NoError(t, err)
 		require.Equal(t, bs, bs2)
 	})

--- a/network/validator_network.go
+++ b/network/validator_network.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill/logger"
 	"github.com/alphabill-org/alphabill/network/protocol/blockproposal"
@@ -271,7 +272,7 @@ func (n *validatorNetwork) UnregisterValidatorProtocols() {
 }
 
 func (n *validatorNetwork) PublishBlock(ctx context.Context, block *types.Block) error {
-	blockBytes, err := types.Cbor.Marshal(block)
+	blockBytes, err := cbor.Marshal(block)
 	if err != nil {
 		return err
 	}
@@ -416,7 +417,7 @@ func (n *validatorNetwork) handleBlocks(ctx context.Context) {
 		}
 
 		block := &types.Block{}
-		err = types.Cbor.Unmarshal(msg.Data, block)
+		err = cbor.Unmarshal(msg.Data, block)
 		if err != nil {
 			n.log.WarnContext(ctx, "failed to decode block", logger.Error(err))
 			continue

--- a/partition/node.go
+++ b/partition/node.go
@@ -20,6 +20,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill-go-base/util"
 
@@ -484,7 +485,7 @@ func getUCv1(b *types.Block) (*types.UnicityCertificate, error) {
 		return nil, errors.New("block unicity certificate is nil")
 	}
 	uc := &types.UnicityCertificate{Version: 1}
-	return uc, types.Cbor.Unmarshal(b.UnicityCertificate, uc)
+	return uc, cbor.Unmarshal(b.UnicityCertificate, uc)
 }
 
 func (n *Node) restoreBlockProposal(ctx context.Context) {
@@ -1052,7 +1053,7 @@ func (n *Node) handleUnicityCertificate(ctx context.Context, uc *types.UnicityCe
 		return ErrNodeDoesNotHaveLatestBlock
 	}
 	// replace UC
-	n.pendingBlockProposal.UnicityCertificate, err = types.Cbor.Marshal(uc)
+	n.pendingBlockProposal.UnicityCertificate, err = cbor.Marshal(uc)
 	if err != nil {
 		return fmt.Errorf("failed to marshal unicity certificate: %w", err)
 	}
@@ -1528,7 +1529,7 @@ func (n *Node) sendCertificationRequest(ctx context.Context, blockAuthor string)
 			ETHash:          state.ETHash(),
 		},
 	}
-	ucBytes, err := types.Cbor.Marshal(uc)
+	ucBytes, err := cbor.Marshal(uc)
 	if err != nil {
 		return fmt.Errorf("failed to marshal unicity certificate: %w", err)
 	}

--- a/partition/partition_recovery_test.go
+++ b/partition/partition_recovery_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill-go-base/util"
 	test "github.com/alphabill-org/alphabill/internal/testutils"
@@ -1507,17 +1508,17 @@ func TestNode_HandleLedgerReplicationResponse_SumOfEarnedFeesMismatch(t *testing
 }
 
 func copyUC(t *testing.T, uc *types.UnicityCertificate) *types.UnicityCertificate {
-	bytes, err := types.Cbor.Marshal(uc)
+	bytes, err := cbor.Marshal(uc)
 	require.NoError(t, err)
 	newUC := &types.UnicityCertificate{Version: 1}
-	require.NoError(t, types.Cbor.Unmarshal(bytes, newUC))
+	require.NoError(t, cbor.Unmarshal(bytes, newUC))
 	return newUC
 }
 
 func copyBlock(t *testing.T, b *types.Block) *types.Block {
-	bytes, err := types.Cbor.Marshal(b)
+	bytes, err := cbor.Marshal(b)
 	require.NoError(t, err)
 	newBlock := &types.Block{}
-	require.NoError(t, types.Cbor.Unmarshal(bytes, newBlock))
+	require.NoError(t, cbor.Unmarshal(bytes, newBlock))
 	return newBlock
 }

--- a/partition/solo_partition_test.go
+++ b/partition/solo_partition_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/stretchr/testify/require"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/crypto"
 	"github.com/alphabill-org/alphabill-go-base/hash"
 	"github.com/alphabill-org/alphabill-go-base/types"
@@ -546,7 +547,7 @@ func technicalRecord(t *testing.T, ir *types.InputRecord, nodes []string) certif
 		fees[v] = 0
 	}
 	h := hash.New(gocrypto.SHA256.New())
-	h.WriteRaw(types.RawCBOR{0xA0}) // empty map
+	h.WriteRaw(cbor.RawCBOR{0xA0}) // empty map
 	h.Write(fees)
 
 	feeHash, err := h.Sum()

--- a/predicates/runner.go
+++ b/predicates/runner.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/predicates"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill/state"
@@ -48,7 +49,7 @@ type (
 
 func ExtractPredicate(predicateBytes []byte) (*predicates.Predicate, error) {
 	predicate := &predicates.Predicate{}
-	if err := types.Cbor.Unmarshal(predicateBytes, predicate); err != nil {
+	if err := cbor.Unmarshal(predicateBytes, predicate); err != nil {
 		return nil, err
 	}
 	return predicate, nil

--- a/predicates/signature.go
+++ b/predicates/signature.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/predicates/templates"
-	"github.com/alphabill-org/alphabill-go-base/types"
 )
 
 func ExtractPubKey(ownerProof []byte) ([]byte, error) {
@@ -13,7 +13,7 @@ func ExtractPubKey(ownerProof []byte) ([]byte, error) {
 		return nil, errors.New("empty owner proof as input")
 	}
 	sig := templates.P2pkh256Signature{}
-	if err := types.Cbor.Unmarshal(ownerProof, &sig); err != nil {
+	if err := cbor.Unmarshal(ownerProof, &sig); err != nil {
 		return nil, fmt.Errorf("decoding owner proof as Signature: %w", err)
 	}
 	return sig.PubKey, nil

--- a/predicates/templates/template_runner.go
+++ b/predicates/templates/template_runner.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/crypto"
 	sdkpredicates "github.com/alphabill-org/alphabill-go-base/predicates"
 	"github.com/alphabill-org/alphabill-go-base/predicates/templates"
@@ -106,7 +107,7 @@ func executeP2PKH256(pubKeyHash, args []byte, env predicates.TxContext) (bool, e
 		return false, fmt.Errorf("reading tx signature bytes: %w", err)
 	}
 	p2pkh256Signature := templates.P2pkh256Signature{}
-	if err := types.Cbor.Unmarshal(args, &p2pkh256Signature); err != nil {
+	if err := cbor.Unmarshal(args, &p2pkh256Signature); err != nil {
 		return false, fmt.Errorf("failed to decode P2PKH256 signature: %w", err)
 	}
 	if len(pubKeyHash) != 32 {

--- a/predicates/templates/template_runner_test.go
+++ b/predicates/templates/template_runner_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/crypto"
 	sdkpredicates "github.com/alphabill-org/alphabill-go-base/predicates"
 	"github.com/alphabill-org/alphabill-go-base/predicates/templates"
@@ -281,7 +282,7 @@ func TestP2pkh256_Execute(t *testing.T) {
 		// valid owner proof struct (CBOR decoding is success) but invalid data inside
 		// signature is of invalid length
 		signature := templates.P2pkh256Signature{Sig: []byte{1, 2, 3}, PubKey: pubKey}
-		ownerProof, err := types.Cbor.Marshal(signature)
+		ownerProof, err := cbor.Marshal(signature)
 		require.NoError(t, err)
 		res, err := executeP2PKH256(pubKeyHash, ownerProof, execEnv)
 		require.EqualError(t, err, `invalid signature size: expected 65, got 3 (010203)`)
@@ -289,7 +290,7 @@ func TestP2pkh256_Execute(t *testing.T) {
 
 		// OwnerProof.PubKey is of invalid length
 		signature = templates.P2pkh256Signature{Sig: make([]byte, 65), PubKey: []byte{4, 5, 6}}
-		ownerProof, err = types.Cbor.Marshal(signature)
+		ownerProof, err = cbor.Marshal(signature)
 		require.NoError(t, err)
 		res, err = executeP2PKH256(pubKeyHash, ownerProof, execEnv)
 		require.EqualError(t, err, `invalid pubkey size: expected 33, got 3 (040506)`)
@@ -297,7 +298,7 @@ func TestP2pkh256_Execute(t *testing.T) {
 
 		// PubKey hash doesn't match with the hash of the PubKey in OwnerProof
 		signature = templates.P2pkh256Signature{Sig: make([]byte, 65), PubKey: make([]byte, 33)}
-		ownerProof, err = types.Cbor.Marshal(signature)
+		ownerProof, err = cbor.Marshal(signature)
 		require.NoError(t, err)
 		res, err = executeP2PKH256(pubKeyHash, ownerProof, execEnv)
 		require.NoError(t, err, `testing against different public key is not error`)
@@ -305,7 +306,7 @@ func TestP2pkh256_Execute(t *testing.T) {
 
 		// set incorrect first byte, compressed key should start with 0x02 or 0x03
 		signature = templates.P2pkh256Signature{Sig: make([]byte, 65), PubKey: make([]byte, 33)}
-		ownerProof, err = types.Cbor.Marshal(signature)
+		ownerProof, err = cbor.Marshal(signature)
 		require.NoError(t, err)
 		pkh := sha256.Sum256(signature.PubKey)
 		res, err = executeP2PKH256(pkh[:], ownerProof, execEnv)
@@ -317,7 +318,7 @@ func TestP2pkh256_Execute(t *testing.T) {
 		// create valid owner proof struct but invalid data inside
 		// signature is of correct length but invalid
 		signature := templates.P2pkh256Signature{Sig: make([]byte, 65), PubKey: pubKey}
-		ownerProof, err := types.Cbor.Marshal(signature)
+		ownerProof, err := cbor.Marshal(signature)
 		require.NoError(t, err)
 		res, err := executeP2PKH256(pubKeyHash, ownerProof, execEnv)
 		require.NoError(t, err)

--- a/predicates/wasm/wasm_engine.go
+++ b/predicates/wasm/wasm_engine.go
@@ -8,6 +8,7 @@ import (
 
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/predicates"
 	"github.com/alphabill-org/alphabill-go-base/predicates/wasm"
 	"github.com/alphabill-org/alphabill-go-base/types"
@@ -50,7 +51,7 @@ func (wr WasmRunner) Execute(ctx context.Context, p *predicates.Predicate, args 
 	defer func(start time.Time) { wr.execDur.Record(ctx, time.Since(start).Seconds()) }(time.Now())
 
 	par := wasm.PredicateParams{}
-	if err := types.Cbor.Unmarshal(p.Params, &par); err != nil {
+	if err := cbor.Unmarshal(p.Params, &par); err != nil {
 		return false, fmt.Errorf("decoding predicate parameters: %w", err)
 	}
 

--- a/predicates/wasm/wvm/demo_time_lock_test.go
+++ b/predicates/wasm/wvm/demo_time_lock_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	abcrypto "github.com/alphabill-org/alphabill-go-base/crypto"
 	"github.com/alphabill-org/alphabill-go-base/predicates/wasm"
 	tokenid "github.com/alphabill-org/alphabill-go-base/testutils/tokens"
@@ -51,7 +52,7 @@ func Test_time_lock(t *testing.T) {
 
 	// configuration of the predicate
 	const lockedUntilDate uint64 = 1709683200
-	cfgCBOR, err := types.Cbor.Marshal([]any{lockedUntilDate, ownerPKH})
+	cfgCBOR, err := cbor.Marshal([]any{lockedUntilDate, ownerPKH})
 	require.NoError(t, err)
 	predConf := wasm.PredicateParams{Entrypoint: "time_lock", Args: cfgCBOR}
 
@@ -153,7 +154,7 @@ func Test_time_lock(t *testing.T) {
 		}
 
 		// date is not uint (unix timestamp)
-		cfgCBOR, err := types.Cbor.Marshal([]any{"2025-04-01 12:00:00", ownerPKH})
+		cfgCBOR, err := cbor.Marshal([]any{"2025-04-01 12:00:00", ownerPKH})
 		require.NoError(t, err)
 		predConf := wasm.PredicateParams{Entrypoint: "time_lock", Args: cfgCBOR}
 		start, curGas := time.Now(), env.GasRemaining
@@ -164,7 +165,7 @@ func Test_time_lock(t *testing.T) {
 		require.EqualValues(t, 0xc01, res)
 
 		// missing owner PKH
-		cfgCBOR, err = types.Cbor.Marshal([]any{lockedUntilDate})
+		cfgCBOR, err = cbor.Marshal([]any{lockedUntilDate})
 		require.NoError(t, err)
 		predConf = wasm.PredicateParams{Entrypoint: "time_lock", Args: cfgCBOR}
 		start, curGas = time.Now(), env.GasRemaining

--- a/predicates/wasm/wvm/demo_v2_test.go
+++ b/predicates/wasm/wvm/demo_v2_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	abcrypto "github.com/alphabill-org/alphabill-go-base/crypto"
 	predtempl "github.com/alphabill-org/alphabill-go-base/predicates/templates"
 	"github.com/alphabill-org/alphabill-go-base/predicates/wasm"
@@ -60,7 +61,7 @@ func Test_conference_tickets_v2(t *testing.T) {
 	const regularDate uint64 = earlyBirdDate + 100000
 	const earlyBirdPrice uint64 = 1000
 	const regularPrice uint64 = 1500
-	predCfg, err := types.Cbor.Marshal([]any{[]any{earlyBirdDate, regularDate, earlyBirdPrice, regularPrice}, organizerPKH})
+	predCfg, err := cbor.Marshal([]any{[]any{earlyBirdDate, regularDate, earlyBirdPrice, regularPrice}, organizerPKH})
 	require.NoError(t, err)
 
 	// tx system unit/attribute encoder
@@ -402,7 +403,7 @@ func proofOfPayment(t *testing.T, signer abcrypto.Signer, receiverPKH []byte, va
 	txRec := &types.TransactionRecord{Version: 1, TransactionOrder: txBytes, ServerMetadata: &types.ServerMetadata{ActualFee: 25, SuccessIndicator: types.TxStatusSuccessful}}
 	txRecProof := testblock.CreateTxRecordProof(t, txRec, signer, testblock.WithPartitionID(money.DefaultPartitionID))
 
-	b, err := types.Cbor.Marshal([]*types.TxRecordProof{txRecProof})
+	b, err := cbor.Marshal([]*types.TxRecordProof{txRecProof})
 	require.NoError(t, err)
 	return b
 }

--- a/predicates/wasm/wvm/encoder/encoder.go
+++ b/predicates/wasm/wvm/encoder/encoder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill-go-base/types/hex"
 )
@@ -94,7 +95,7 @@ func (enc *TVEnc) Encode(item any) {
 		enc.WriteBytes(it)
 	case hex.Bytes:
 		enc.WriteBytes(it)
-	case types.RawCBOR:
+	case cbor.RawCBOR:
 		enc.WriteBytes(it)
 	case types.UnitID:
 		enc.WriteBytes(it)

--- a/predicates/wasm/wvm/encoder/gen_rust_test.go
+++ b/predicates/wasm/wvm/encoder/gen_rust_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill/internal/testutils/rust"
 )
@@ -63,7 +64,7 @@ func Test_TXSystemEncoder_trigger(t *testing.T) {
 	})
 
 	t.Run("types.RawCBOR", func(t *testing.T) {
-		buf, err := enc.Encode(types.RawCBOR{0, 1, 127, 128, 255}, 1, nil)
+		buf, err := enc.Encode(cbor.RawCBOR{0, 1, 127, 128, 255}, 1, nil)
 		require.NoError(t, err)
 		require.Equal(t, []byte{type_id_bytes, 0x5, 0x0, 0x0, 0x0, 0, 1, 127, 128, 255}, buf)
 	})

--- a/predicates/wasm/wvm/factory.go
+++ b/predicates/wasm/wvm/factory.go
@@ -3,6 +3,7 @@ package wvm
 import (
 	"fmt"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 )
 
@@ -22,7 +23,7 @@ func (ABTypesFactory) createObj(typID uint32, data []byte) (any, error) {
 		return nil, fmt.Errorf("unknown type ID %d", typID)
 	}
 
-	if err := types.Cbor.Unmarshal(data, obj); err != nil {
+	if err := cbor.Unmarshal(data, obj); err != nil {
 		return nil, fmt.Errorf("decoding data as %T: %w", obj, err)
 	}
 	return obj, nil

--- a/predicates/wasm/wvm/factory_test.go
+++ b/predicates/wasm/wvm/factory_test.go
@@ -3,6 +3,7 @@ package wvm
 import (
 	"testing"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/stretchr/testify/require"
 )
@@ -43,7 +44,7 @@ func Test_ABTypesFactory_createObj(t *testing.T) {
 			AuthProof: []byte{1},
 			FeeProof:  []byte{2},
 		}
-		buf, err := types.Cbor.Marshal(txo)
+		buf, err := cbor.Marshal(txo)
 		require.NoError(t, err)
 
 		f := ABTypesFactory{}
@@ -65,7 +66,7 @@ func Test_ABTypesFactory_createObj(t *testing.T) {
 				SuccessIndicator: types.TxStatusSuccessful,
 			},
 		}
-		buf, err := types.Cbor.Marshal(txr)
+		buf, err := cbor.Marshal(txr)
 		require.NoError(t, err)
 
 		f := ABTypesFactory{}
@@ -80,7 +81,7 @@ func Test_ABTypesFactory_createObj(t *testing.T) {
 			BlockHeaderHash: []byte{5, 5, 5},
 			Chain:           []*types.GenericChainItem{{Hash: []byte{4}}},
 		}
-		buf, err := types.Cbor.Marshal(txp)
+		buf, err := cbor.Marshal(txp)
 		require.NoError(t, err)
 
 		f := ABTypesFactory{}

--- a/predicates/wasm/wvm/module_ab.go
+++ b/predicates/wasm/wvm/module_ab.go
@@ -10,6 +10,7 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/predicates/templates"
 	"github.com/alphabill-org/alphabill-go-base/txsystem/money"
 	"github.com/alphabill-org/alphabill-go-base/types"
@@ -121,7 +122,7 @@ func amountTransferred(vec *vmContext, mod api.Module, stack []uint64) error {
 		return fmt.Errorf("reading input data: %w", err)
 	}
 	var txs []*types.TxRecordProof
-	if err := types.Cbor.Unmarshal(data, &txs); err != nil {
+	if err := cbor.Unmarshal(data, &txs); err != nil {
 		return fmt.Errorf("decoding data as slice of tx proofs: %w", err)
 	}
 

--- a/predicates/wasm/wvm/module_cbor.go
+++ b/predicates/wasm/wvm/module_cbor.go
@@ -8,7 +8,7 @@ import (
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 
-	"github.com/alphabill-org/alphabill-go-base/types"
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 )
 
 /*
@@ -35,7 +35,7 @@ func cborParse(vec *vmContext, mod api.Module, stack []uint64) error {
 	}
 
 	var items any
-	if err := types.Cbor.Unmarshal(data, &items); err != nil {
+	if err := cbor.Unmarshal(data, &items); err != nil {
 		return fmt.Errorf("decoding as CBOR: %w", err)
 	}
 
@@ -70,8 +70,8 @@ func cborChunks(vec *vmContext, mod api.Module, stack []uint64) error {
 		return fmt.Errorf("reading variable: %w", err)
 	}
 
-	var items []types.RawCBOR
-	if err := types.Cbor.Unmarshal(data, &items); err != nil {
+	var items []cbor.RawCBOR
+	if err := cbor.Unmarshal(data, &items); err != nil {
 		return fmt.Errorf("decoding as CBOR: %w", err)
 	}
 

--- a/predicates/wasm/wvm/module_cbor_test.go
+++ b/predicates/wasm/wvm/module_cbor_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tetratelabs/wazero/api"
 
-	"github.com/alphabill-org/alphabill-go-base/types"
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill/internal/testutils/logger"
 	"github.com/alphabill-org/alphabill/predicates/wasm/wvm/bumpallocator"
 )
@@ -75,7 +75,7 @@ func Test_cborParse(t *testing.T) {
 	})
 
 	t.Run("success, array", func(t *testing.T) {
-		conf, err := types.Cbor.Marshal([]any{1234567890, []byte{1, 2, 3, 4, 5}})
+		conf, err := cbor.Marshal([]any{1234567890, []byte{1, 2, 3, 4, 5}})
 		require.NoError(t, err)
 		ctx := &vmContext{
 			curPrg: &evalContext{
@@ -110,7 +110,7 @@ func Test_cborParse(t *testing.T) {
 }
 
 func Test_cborChunks(t *testing.T) {
-	cborData, err := types.Cbor.Marshal([]any{1234567890, []byte{1, 2, 3, 4, 5}})
+	cborData, err := cbor.Marshal([]any{1234567890, []byte{1, 2, 3, 4, 5}})
 	require.NoError(t, err)
 	vm := &vmContext{
 		curPrg: &evalContext{
@@ -143,15 +143,15 @@ func Test_cborChunks(t *testing.T) {
 
 	// the first handle is for cbor encoded uint64
 	var v any
-	buf, err := getVar[types.RawCBOR](vm.curPrg.vars, handles[0])
+	buf, err := getVar[cbor.RawCBOR](vm.curPrg.vars, handles[0])
 	require.NoError(t, err)
-	require.NoError(t, types.Cbor.Unmarshal(buf, &v))
+	require.NoError(t, cbor.Unmarshal(buf, &v))
 	require.Equal(t, uint64(1234567890), v)
 
 	// the second handle is for cbor encoded byte slice
-	buf, err = getVar[types.RawCBOR](vm.curPrg.vars, handles[1])
+	buf, err = getVar[cbor.RawCBOR](vm.curPrg.vars, handles[1])
 	require.NoError(t, err)
-	require.NoError(t, types.Cbor.Unmarshal(buf, &v))
+	require.NoError(t, cbor.Unmarshal(buf, &v))
 	require.Equal(t, []byte{1, 2, 3, 4, 5}, v)
 }
 

--- a/predicates/wasm/wvm/wvm.go
+++ b/predicates/wasm/wvm/wvm.go
@@ -12,6 +12,7 @@ import (
 	"github.com/tetratelabs/wazero/api"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/predicates/wasm"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill/logger"
@@ -131,7 +132,7 @@ func (vmc *vmContext) getBytesVariable(handle uint32) ([]byte, error) {
 	switch d := v.(type) {
 	case []byte:
 		return d, nil
-	case types.RawCBOR:
+	case cbor.RawCBOR:
 		return d, nil
 	case nil:
 		return nil, nil

--- a/rootchain/consensus/storage/block_executor_test.go
+++ b/rootchain/consensus/storage/block_executor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill/internal/testutils/logger"
 	"github.com/alphabill-org/alphabill/network/protocol/certification"
@@ -399,19 +400,19 @@ func Test_ExecutedBlock_serialization(t *testing.T) {
 		// considers nil and empty map as different. In code the ExecutedBlock
 		// values are constructed via constructors which init the Changed field.
 		b1 := ExecutedBlock{ShardState: ShardStates{Changed: ShardSet{}}}
-		buf, err := types.Cbor.Marshal(b1)
+		buf, err := cbor.Marshal(b1)
 		require.NoError(t, err)
 
 		var b2 ExecutedBlock
-		require.NoError(t, types.Cbor.Unmarshal(buf, &b2))
+		require.NoError(t, cbor.Unmarshal(buf, &b2))
 		require.EqualValues(t, b1.ShardState.Changed, b2.ShardState.Changed)
 
 		// set with one item (empty shard ID)
 		b1.ShardState.Changed = map[types.PartitionShardID]struct{}{{PartitionID: 1, ShardID: types.ShardID{}.Key()}: {}}
-		buf, err = types.Cbor.Marshal(b1)
+		buf, err = cbor.Marshal(b1)
 		require.NoError(t, err)
 
-		require.NoError(t, types.Cbor.Unmarshal(buf, &b2))
+		require.NoError(t, cbor.Unmarshal(buf, &b2))
 		require.EqualValues(t, b1.ShardState.Changed, b2.ShardState.Changed)
 
 		// set with two shards
@@ -420,21 +421,21 @@ func Test_ExecutedBlock_serialization(t *testing.T) {
 			{PartitionID: 2, ShardID: s0.Key()}: {},
 			{PartitionID: 2, ShardID: s1.Key()}: {},
 		}
-		buf, err = types.Cbor.Marshal(b1)
+		buf, err = cbor.Marshal(b1)
 		require.NoError(t, err)
 
-		require.NoError(t, types.Cbor.Unmarshal(buf, &b2))
+		require.NoError(t, cbor.Unmarshal(buf, &b2))
 		require.EqualValues(t, b1.ShardState.Changed, b2.ShardState.Changed)
 	})
 
 	t.Run("ShardInfo", func(t *testing.T) {
 		// empty map
 		b1 := ExecutedBlock{ShardState: ShardStates{States: map[types.PartitionShardID]*ShardInfo{}}}
-		buf, err := types.Cbor.Marshal(b1)
+		buf, err := cbor.Marshal(b1)
 		require.NoError(t, err)
 
 		var b2 ExecutedBlock
-		require.NoError(t, types.Cbor.Unmarshal(buf, &b2))
+		require.NoError(t, cbor.Unmarshal(buf, &b2))
 		require.EqualValues(t, b1.ShardState.States, b2.ShardState.States)
 
 		// non-empty map
@@ -460,10 +461,10 @@ func Test_ExecutedBlock_serialization(t *testing.T) {
 		}
 		psKey := types.PartitionShardID{PartitionID: si.LastCR.Partition, ShardID: si.LastCR.Shard.Key()}
 		b1.ShardState.States[psKey] = &si
-		buf, err = types.Cbor.Marshal(b1)
+		buf, err = cbor.Marshal(b1)
 		require.NoError(t, err)
 
-		require.NoError(t, types.Cbor.Unmarshal(buf, &b2))
+		require.NoError(t, cbor.Unmarshal(buf, &b2))
 		require.Equal(t, b1.ShardState.States, b2.ShardState.States)
 		require.Equal(t, &si, b2.ShardState.States[psKey])
 	})

--- a/rootchain/consensus/storage/db_bolt_test.go
+++ b/rootchain/consensus/storage/db_bolt_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/bbolt"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	test "github.com/alphabill-org/alphabill/internal/testutils"
 	"github.com/alphabill-org/alphabill/network/protocol/abdrc"
@@ -191,7 +192,7 @@ func Test_BoltDB_VoteMsg(t *testing.T) {
 		require.Empty(t, msg)
 
 		// invalid type enum value
-		encoded, err := types.Cbor.Marshal(VoteStore{VoteType: 10})
+		encoded, err := cbor.Marshal(VoteStore{VoteType: 10})
 		require.NoError(t, err)
 		err = db.db.Update(func(tx *bbolt.Tx) error {
 			b := tx.Bucket(bucketVotes)

--- a/rootchain/consensus/storage/db_migrate_0_1.go
+++ b/rootchain/consensus/storage/db_migrate_0_1.go
@@ -9,7 +9,7 @@ import (
 
 	"go.etcd.io/bbolt"
 
-	"github.com/alphabill-org/alphabill-go-base/types"
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	rctypes "github.com/alphabill-org/alphabill/rootchain/consensus/types"
 )
 
@@ -60,7 +60,7 @@ func (db BoltDB) migrate_0_to_1() error {
 			switch keyStr := string(k); {
 			case strings.HasPrefix(keyStr, "block_"):
 				var b ExecutedBlock
-				if err := types.Cbor.Unmarshal(v, &b); err != nil {
+				if err := cbor.Unmarshal(v, &b); err != nil {
 					return fmt.Errorf("loading block %x: %w", k, err)
 				}
 				blocks = append(blocks, &b)
@@ -91,7 +91,7 @@ func (db BoltDB) migrate_0_to_1() error {
 			return fmt.Errorf("bucket %s doesn't exist", bucketBlocks)
 		}
 		for _, v := range blocks {
-			data, err := types.Cbor.Marshal(v)
+			data, err := cbor.Marshal(v)
 			if err != nil {
 				return fmt.Errorf("serializing block: %w", err)
 			}
@@ -126,7 +126,7 @@ func (db BoltDB) migrate_0_to_1() error {
 				return fmt.Errorf("bucket %s doesn't exist", bucketSafety)
 			}
 			var round uint64
-			if err := types.Cbor.Unmarshal(highQCR, &round); err != nil {
+			if err := cbor.Unmarshal(highQCR, &round); err != nil {
 				return fmt.Errorf("loading high QC round: %w", err)
 			}
 			if err = writeUint64(b, keyHighestQc, round); err != nil {
@@ -138,7 +138,7 @@ func (db BoltDB) migrate_0_to_1() error {
 				return fmt.Errorf("bucket %s doesn't exist", bucketSafety)
 			}
 			var round uint64
-			if err := types.Cbor.Unmarshal(highVR, &round); err != nil {
+			if err := cbor.Unmarshal(highVR, &round); err != nil {
 				return fmt.Errorf("loading high voted round: %w", err)
 			}
 			if err = writeUint64(b, keyHighestVoted, round); err != nil {

--- a/rootchain/consensus/storage/sharding.go
+++ b/rootchain/consensus/storage/sharding.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	abcrypto "github.com/alphabill-org/alphabill-go-base/crypto"
 	abhash "github.com/alphabill-org/alphabill-go-base/hash"
 	"github.com/alphabill-org/alphabill-go-base/types"
@@ -221,7 +222,7 @@ func (ss ShardStates) MarshalCBOR() ([]byte, error) {
 		d.Data[idx] = si
 		idx++
 	}
-	buf, err := types.Cbor.Marshal(d)
+	buf, err := cbor.Marshal(d)
 	if err != nil {
 		return nil, fmt.Errorf("serializing shard states: %w", err)
 	}
@@ -230,7 +231,7 @@ func (ss ShardStates) MarshalCBOR() ([]byte, error) {
 
 func (ss *ShardStates) UnmarshalCBOR(data []byte) error {
 	var d ssItems
-	if err := types.Cbor.Unmarshal(data, &d); err != nil {
+	if err := cbor.Unmarshal(data, &d); err != nil {
 		return fmt.Errorf("decoding shard states: %w", err)
 	}
 	if d.Version != 1 {
@@ -258,12 +259,12 @@ func NewShardInfo(shardConf *types.PartitionDescriptionRecord, hashAlg crypto.Ha
 		T2Timeout:     shardConf.T2Timeout,
 		ShardConfHash: shardConfHash,
 		RootHash:      nil,
-		PrevEpochFees: types.RawCBOR{0xA0}, // CBOR map(0)
+		PrevEpochFees: cbor.RawCBOR{0xA0}, // CBOR map(0)
 		LastCR:        nil,
 		IR:            &types.InputRecord{Version: 1},
 	}
 
-	if si.PrevEpochStat, err = types.Cbor.Marshal(si.Stat); err != nil {
+	if si.PrevEpochStat, err = cbor.Marshal(si.Stat); err != nil {
 		return nil, fmt.Errorf("init previous epoch stat: %w", err)
 	}
 
@@ -298,7 +299,7 @@ func newShardTechnicalRecord(shardConf *types.PartitionDescriptionRecord, valida
 		fees[v] = 0
 	}
 	h := abhash.New(crypto.SHA256.New())
-	h.WriteRaw(types.RawCBOR{0xA0}) // empty map
+	h.WriteRaw(cbor.RawCBOR{0xA0}) // empty map
 	h.Write(fees)
 
 	var err error
@@ -319,7 +320,7 @@ type ShardInfo struct {
 
 	// statistical record of the previous epoch. As we only need
 	// it for hashing we keep it in serialized representation
-	PrevEpochStat types.RawCBOR
+	PrevEpochStat cbor.RawCBOR
 
 	// statistical record of the current epoch
 	Stat certification.StatisticalRecord
@@ -327,7 +328,7 @@ type ShardInfo struct {
 	// per validator total, invariant fees of the previous epoch
 	// but as with statistical record of the previous epoch we need it
 	// for hashing so we keep it in serialized representation
-	PrevEpochFees types.RawCBOR
+	PrevEpochFees cbor.RawCBOR
 
 	Fees map[string]uint64 // per validator summary fees of the current epoch
 
@@ -396,10 +397,10 @@ func (si *ShardInfo) nextEpoch(shardConf *types.PartitionDescriptionRecord, hash
 		TR:            si.TR,
 	}
 
-	if nextSI.PrevEpochFees, err = types.Cbor.Marshal(si.Fees); err != nil {
+	if nextSI.PrevEpochFees, err = cbor.Marshal(si.Fees); err != nil {
 		return nil, fmt.Errorf("encoding previous epoch fees: %w", err)
 	}
-	if nextSI.PrevEpochStat, err = types.Cbor.Marshal(si.Stat); err != nil {
+	if nextSI.PrevEpochStat, err = cbor.Marshal(si.Stat); err != nil {
 		return nil, fmt.Errorf("encoding previous epoch stat: %w", err)
 	}
 
@@ -557,7 +558,7 @@ func (ss ShardSet) MarshalCBOR() ([]byte, error) {
 		idx++
 	}
 	buf := bytes.Buffer{}
-	if err := types.Cbor.Encode(&buf, d); err != nil {
+	if err := cbor.Encode(&buf, d); err != nil {
 		return nil, fmt.Errorf("encoding shard set data: %w", err)
 	}
 	return buf.Bytes(), nil
@@ -565,7 +566,7 @@ func (ss ShardSet) MarshalCBOR() ([]byte, error) {
 
 func (ss *ShardSet) UnmarshalCBOR(data []byte) error {
 	var d []shardSetItem
-	if err := types.Cbor.Unmarshal(data, &d); err != nil {
+	if err := cbor.Unmarshal(data, &d); err != nil {
 		return fmt.Errorf("decoding shard set data: %w", err)
 	}
 	ssn := make(ShardSet, len(d))

--- a/rootchain/consensus/storage/sharding_test.go
+++ b/rootchain/consensus/storage/sharding_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	abcrypto "github.com/alphabill-org/alphabill-go-base/crypto"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	testcertificates "github.com/alphabill-org/alphabill/internal/testutils/certificates"
@@ -425,11 +426,11 @@ func Test_ShardInfo_NextEpoch(t *testing.T) {
 	      43 # "C"
 	   03    # unsigned(3)
 	*/
-	require.Equal(t, types.RawCBOR{0xa3, 0x61, 0x41, 0x1, 0x61, 0x42, 0x2, 0x61, 0x43, 0x3}, nextSI.PrevEpochFees)
+	require.Equal(t, cbor.RawCBOR{0xa3, 0x61, 0x41, 0x1, 0x61, 0x42, 0x2, 0x61, 0x43, 0x3}, nextSI.PrevEpochFees)
 	// fee list is initialized to new validator list
 	require.Equal(t, map[string]uint64{"2222": 0}, nextSI.Fees)
 	// array of 7 items, sorted by field order in the struct
-	require.Equal(t, types.RawCBOR{0x87, 0, 1, 2, 3, 4, 5, 6}, nextSI.PrevEpochStat)
+	require.Equal(t, cbor.RawCBOR{0x87, 0, 1, 2, 3, 4, 5, 6}, nextSI.PrevEpochStat)
 	require.Equal(t, certification.StatisticalRecord{}, nextSI.Stat, "expected stat to be reset")
 }
 
@@ -481,8 +482,8 @@ func Test_NewShardInfoFromGenesis(t *testing.T) {
 		require.Nil(t, si.LastCR)
 		require.Equal(t, certification.StatisticalRecord{}, si.Stat)
 		require.Equal(t, map[string]uint64{nodeID: 0}, si.Fees)
-		require.Equal(t, types.RawCBOR{0xA0}, si.PrevEpochFees)
-		require.Equal(t, types.RawCBOR{0x87, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, si.PrevEpochStat)
+		require.Equal(t, cbor.RawCBOR{0xA0}, si.PrevEpochFees)
+		require.Equal(t, cbor.RawCBOR{0x87, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, si.PrevEpochStat)
 	})
 }
 

--- a/rootchain/consensus/types/ir_change_request_test.go
+++ b/rootchain/consensus/types/ir_change_request_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	abhash "github.com/alphabill-org/alphabill-go-base/hash"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill/network/protocol/certification"
@@ -78,14 +79,14 @@ func TestIRChangeReqMsg_Marshal(t *testing.T) {
 	hash, err := irHasher.Sum()
 	require.NoError(t, err)
 
-	bs, err := types.Cbor.Marshal(ircr)
+	bs, err := cbor.Marshal(ircr)
 	require.NoError(t, err)
 	hshr := crypto.SHA256.New()
 	hshr.Write(bs)
 	require.Equal(t, hash, hshr.Sum(nil))
 
 	ircr2 := &IRChangeReq{}
-	require.NoError(t, types.Cbor.Unmarshal(bs, ircr2))
+	require.NoError(t, cbor.Unmarshal(bs, ircr2))
 	require.Equal(t, ircr, ircr2)
 }
 

--- a/rootchain/consensus/types/proposal_block.go
+++ b/rootchain/consensus/types/proposal_block.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	abhash "github.com/alphabill-org/alphabill-go-base/hash"
 	"github.com/alphabill-org/alphabill-go-base/types"
 )
@@ -145,12 +146,12 @@ func (x *BlockData) MarshalCBOR() ([]byte, error) {
 	if x.Version == 0 {
 		x.Version = x.GetVersion()
 	}
-	return types.Cbor.MarshalTaggedValue(types.RootPartitionBlockDataTag, (*alias)(x))
+	return cbor.MarshalTaggedValue(types.RootPartitionBlockDataTag, (*alias)(x))
 }
 
 func (x *BlockData) UnmarshalCBOR(data []byte) error {
 	type alias BlockData
-	if err := types.Cbor.UnmarshalTaggedValue(types.RootPartitionBlockDataTag, data, (*alias)(x)); err != nil {
+	if err := cbor.UnmarshalTaggedValue(types.RootPartitionBlockDataTag, data, (*alias)(x)); err != nil {
 		return err
 	}
 	return types.EnsureVersion(x, x.Version, 1)

--- a/rootchain/consensus/types/proposal_block_test.go
+++ b/rootchain/consensus/types/proposal_block_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"testing"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill-go-base/types/hex"
 	"github.com/stretchr/testify/require"
@@ -29,7 +30,7 @@ func TestBlockDataHash(t *testing.T) {
 		},
 	}
 
-	serializedBlock, err := types.Cbor.Marshal(block)
+	serializedBlock, err := cbor.Marshal(block)
 	require.NoError(t, err)
 	expected := sha256.Sum256(serializedBlock)
 

--- a/rootchain/consensus/types/round_info.go
+++ b/rootchain/consensus/types/round_info.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	abhash "github.com/alphabill-org/alphabill-go-base/hash"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill-go-base/types/hex"
@@ -74,12 +75,12 @@ func (x *RoundInfo) MarshalCBOR() ([]byte, error) {
 	if x.Version == 0 {
 		x.Version = x.GetVersion()
 	}
-	return types.Cbor.MarshalTaggedValue(types.RootPartitionRoundInfoTag, (*alias)(x))
+	return cbor.MarshalTaggedValue(types.RootPartitionRoundInfoTag, (*alias)(x))
 }
 
 func (x *RoundInfo) UnmarshalCBOR(data []byte) error {
 	type alias RoundInfo
-	if err := types.Cbor.UnmarshalTaggedValue(types.RootPartitionRoundInfoTag, data, (*alias)(x)); err != nil {
+	if err := cbor.UnmarshalTaggedValue(types.RootPartitionRoundInfoTag, data, (*alias)(x)); err != nil {
 		return err
 	}
 	return types.EnsureVersion(x, x.Version, 1)

--- a/rpc/rest_node.go
+++ b/rpc/rest_node.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill/logger"
 	"github.com/gorilla/mux"
@@ -26,7 +27,7 @@ func getState(node partitionNode, log *slog.Logger) http.HandlerFunc {
 		if err := node.SerializeState(w); err != nil {
 			w.Header().Set("Content-Type", "application/cbor")
 			w.WriteHeader(http.StatusInternalServerError)
-			if err := types.Cbor.Encode(w, struct {
+			if err := cbor.Encode(w, struct {
 				_   struct{} `cbor:",toarray"`
 				Err string
 			}{

--- a/rpc/state_api.go
+++ b/rpc/state_api.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill-go-base/types/hex"
 	"github.com/alphabill-org/alphabill/partition"
@@ -197,7 +198,7 @@ func (s *StateAPI) SendTransaction(ctx context.Context, txBytes hex.Bytes) (_ he
 		return nil, fmt.Errorf("request not allowed: %w", err)
 	}
 	var tx *types.TransactionOrder
-	if err := types.Cbor.Unmarshal(txBytes, &tx); err != nil {
+	if err := cbor.Unmarshal(txBytes, &tx); err != nil {
 		s.updTxReceived(ctx, 0, err)
 		return nil, fmt.Errorf("failed to decode transaction: %w", err)
 	}
@@ -223,7 +224,7 @@ func (s *StateAPI) GetTransactionProof(ctx context.Context, txHash hex.Bytes) (_
 		}
 		return nil, fmt.Errorf("failed to load tx record: %w", err)
 	}
-	txRecordProofCBOR, err := types.Cbor.Marshal(txRecordProof)
+	txRecordProofCBOR, err := cbor.Marshal(txRecordProof)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode tx record: %w", err)
 	}
@@ -245,7 +246,7 @@ func (s *StateAPI) GetBlock(ctx context.Context, blockNumber hex.Uint64) (_ hex.
 	if block == nil {
 		return nil, nil
 	}
-	blockCbor, err := types.Cbor.Marshal(block)
+	blockCbor, err := cbor.Marshal(block)
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode block: %w", err)
 	}

--- a/rpc/state_api_test.go
+++ b/rpc/state_api_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	abhash "github.com/alphabill-org/alphabill-go-base/hash"
 	"github.com/alphabill-org/alphabill-go-base/predicates/templates"
 	"github.com/alphabill-org/alphabill-go-base/txsystem/money"
@@ -313,7 +314,7 @@ func TestGetTransactionProof(t *testing.T) {
 		require.NotNil(t, res.TxRecordProof)
 
 		var txRecordProof *types.TxRecordProof
-		err = types.Cbor.Unmarshal(res.TxRecordProof, &txRecordProof)
+		err = cbor.Unmarshal(res.TxRecordProof, &txRecordProof)
 		require.NoError(t, err)
 		require.NotNil(t, txRecordProof)
 	})
@@ -340,7 +341,7 @@ func TestGetBlock(t *testing.T) {
 		require.NotNil(t, res)
 
 		var block *types.Block
-		err = types.Cbor.Unmarshal(res, &block)
+		err = cbor.Unmarshal(res, &block)
 		require.NoError(t, err)
 		rn, err := block.GetRoundNumber()
 		require.NoError(t, err)
@@ -568,7 +569,7 @@ func createTransactionOrder(t *testing.T, unitID types.UnitID) []byte {
 		Counter:           0,
 	}
 
-	attBytes, err := types.Cbor.Marshal(bt)
+	attBytes, err := cbor.Marshal(bt)
 	require.NoError(t, err)
 
 	txo := &types.TransactionOrder{
@@ -583,7 +584,7 @@ func createTransactionOrder(t *testing.T, unitID types.UnitID) []byte {
 	authProof := money.TransferAuthProof{OwnerProof: []byte{1}}
 	require.NoError(t, txo.SetAuthProof(authProof))
 
-	txoCBOR, err := types.Cbor.Marshal(txo)
+	txoCBOR, err := cbor.Marshal(txo)
 	require.NoError(t, err)
 	return txoCBOR
 }

--- a/state/state.go
+++ b/state/state.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"sync"
 
+	abcbor "github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/tree/mt"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill-go-base/util"
@@ -90,7 +91,7 @@ func readNodeRecords(decoder *cbor.Decoder, unitDataConstructor UnitDataConstruc
 			return nil, fmt.Errorf("unable to construct unit data: %w", err)
 		}
 
-		err = types.Cbor.Unmarshal(nodeRecord.UnitData, &unitData)
+		err = abcbor.Unmarshal(nodeRecord.UnitData, &unitData)
 		if err != nil {
 			return nil, fmt.Errorf("unable to decode unit data: %w", err)
 		}
@@ -323,7 +324,7 @@ func (s *State) Size() (uint64, error) {
 // Not concurrency safe. Should clone the state before calling this.
 func (s *State) Serialize(writer io.Writer, committed bool, executedTransactions map[string]uint64) error {
 	crc32Writer := NewCRC32Writer(writer)
-	encoder, err := types.Cbor.GetEncoder(crc32Writer)
+	encoder, err := abcbor.GetEncoder(crc32Writer)
 	if err != nil {
 		return fmt.Errorf("unable to get encoder: %w", err)
 	}

--- a/state/state_deserializer.go
+++ b/state/state_deserializer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill-go-base/util"
 	"github.com/alphabill-org/alphabill/tree/avl"
@@ -12,7 +13,7 @@ import (
 func readState(stateData io.Reader, udc UnitDataConstructor, opts ...Option) (*State, *Header, error) {
 	options := loadOptions(opts...)
 	crc32Reader := NewCRC32Reader(stateData, CBORChecksumLength)
-	decoder := types.Cbor.GetDecoder(crc32Reader)
+	decoder := cbor.GetDecoder(crc32Reader)
 
 	var header Header
 	err := decoder.Decode(&header)

--- a/state/state_serializer.go
+++ b/state/state_serializer.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"fmt"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/tree/mt"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill/tree/avl"
@@ -25,7 +26,7 @@ type (
 		_                  struct{} `cbor:",toarray"`
 		Version            types.ABVersion
 		UnitID             types.UnitID
-		UnitData           types.RawCBOR
+		UnitData           cbor.RawCBOR
 		UnitLedgerHeadHash []byte
 		UnitTreePath       []*mt.PathItem
 		HasLeft            bool
@@ -71,7 +72,7 @@ func (s *stateSerializer) WriteNode(n *avl.Node[types.UnitID, Unit]) error {
 	}
 
 	latestLog := unit.logs[logSize-1]
-	unitDataBytes, err := types.Cbor.Marshal(latestLog.NewUnitData)
+	unitDataBytes, err := cbor.Marshal(latestLog.NewUnitData)
 	if err != nil {
 		return fmt.Errorf("unable to encode unit data: %w", err)
 	}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	abhash "github.com/alphabill-org/alphabill-go-base/hash"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill-go-base/util"
@@ -986,7 +987,7 @@ func unitDataConstructor(_ types.UnitID) (types.UnitData, error) {
 func createSerializedState(t *testing.T, s *State, h *Header, checksum uint32) *bytes.Buffer {
 	buf := &bytes.Buffer{}
 	crc32Writer := NewCRC32Writer(buf)
-	encoder, err := types.Cbor.GetEncoder(crc32Writer)
+	encoder, err := cbor.GetEncoder(crc32Writer)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/state/unit.go
+++ b/state/unit.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"fmt"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	abhash "github.com/alphabill-org/alphabill-go-base/hash"
 	"github.com/alphabill-org/alphabill-go-base/types"
 )
@@ -106,7 +107,7 @@ func (u *UnitV1) IsExpired(currentRoundNumber uint64) bool {
 }
 
 func MarshalUnitData(u types.UnitData) ([]byte, error) {
-	return types.Cbor.Marshal(u)
+	return cbor.Marshal(u)
 }
 
 func copyLogs(entries []*Log) []*Log {

--- a/txsystem/fc/permissioned/tx_executor_set_fc_test.go
+++ b/txsystem/fc/permissioned/tx_executor_set_fc_test.go
@@ -3,6 +3,7 @@ package permissioned
 import (
 	"testing"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/crypto"
 	"github.com/alphabill-org/alphabill-go-base/predicates/templates"
 	moneyid "github.com/alphabill-org/alphabill-go-base/testutils/money"
@@ -224,7 +225,7 @@ func newSetFeeCreditTx(adminKey crypto.Signer, partitionID types.PartitionID, un
 }
 
 func newTxPayload(partitionID types.PartitionID, txType uint16, unitID, fcrID types.UnitID, timeout uint64, refNo []byte, attr interface{}) (types.Payload, error) {
-	attrBytes, err := types.Cbor.Marshal(attr)
+	attrBytes, err := cbor.Marshal(attr)
 	if err != nil {
 		return types.Payload{}, err
 	}

--- a/txsystem/generic_tx_system_test.go
+++ b/txsystem/generic_tx_system_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	abhash "github.com/alphabill-org/alphabill-go-base/hash"
 	"github.com/alphabill-org/alphabill-go-base/predicates/templates"
 	fcsdk "github.com/alphabill-org/alphabill-go-base/txsystem/fc"
@@ -396,7 +397,7 @@ func Test_GenericTxSystem_Execute_FeeTransactions(t *testing.T) {
 			}),
 			transaction.WithStateLock(&types.StateLock{}),
 		)
-		txOnHoldBytes, err := types.Cbor.Marshal(txOnHold)
+		txOnHoldBytes, err := cbor.Marshal(txOnHold)
 		require.NoError(t, err)
 
 		// create FCR unit with txOnHold
@@ -459,7 +460,7 @@ func Test_GenericTxSystem_Execute_FeeTransactions(t *testing.T) {
 		require.NoError(t, err)
 		unitV1, err := state.ToUnitV1(u)
 		require.NoError(t, err)
-		expectedTxBytes, err := types.Cbor.Marshal(tx)
+		expectedTxBytes, err := cbor.Marshal(tx)
 		require.NoError(t, err)
 		require.Equal(t, expectedTxBytes, unitV1.StateLockTx())
 
@@ -743,7 +744,7 @@ type MockSplitTxAttributes struct {
 
 func newMockLockTx(t *testing.T, option ...transaction.Option) []byte {
 	txo := transaction.NewTransactionOrder(t, option...)
-	txBytes, err := types.Cbor.Marshal(txo)
+	txBytes, err := cbor.Marshal(txo)
 	require.NoError(t, err)
 	return txBytes
 }

--- a/txsystem/money/money_integration_test.go
+++ b/txsystem/money/money_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	abcrypto "github.com/alphabill-org/alphabill-go-base/crypto"
 	"github.com/alphabill-org/alphabill-go-base/predicates/templates"
 	fcsdk "github.com/alphabill-org/alphabill-go-base/txsystem/fc"
@@ -289,7 +290,7 @@ func TestPartition_SwapDCOk(t *testing.T) {
 
 	// create swap order
 	swapAttr := &money.SwapDCAttributes{DustTransferProofs: dcRecordProofs}
-	swapAttrBytes, err := types.Cbor.Marshal(swapAttr)
+	swapAttrBytes, err := cbor.Marshal(swapAttr)
 	require.NoError(t, err)
 
 	// create swap tx

--- a/txsystem/money/money_tx_system_test.go
+++ b/txsystem/money/money_tx_system_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	abcrypto "github.com/alphabill-org/alphabill-go-base/crypto"
 	abhash "github.com/alphabill-org/alphabill-go-base/hash"
 	"github.com/alphabill-org/alphabill-go-base/predicates/templates"
@@ -434,7 +435,7 @@ func TestBillData_AddToHasher(t *testing.T) {
 	}
 
 	hasher := crypto.SHA256.New()
-	res, err := types.Cbor.Marshal(bd)
+	res, err := cbor.Marshal(bd)
 	require.NoError(t, err)
 	hasher.Write(res)
 	expectedHash := hasher.Sum(nil)
@@ -446,7 +447,7 @@ func TestBillData_AddToHasher(t *testing.T) {
 	require.Equal(t, expectedHash, actualHash)
 	// make sure all fields where serialized
 	var bdFormSerialized money.BillData
-	require.NoError(t, types.Cbor.Unmarshal(res, &bdFormSerialized))
+	require.NoError(t, cbor.Unmarshal(res, &bdFormSerialized))
 	require.Equal(t, bd, &bdFormSerialized)
 }
 

--- a/txsystem/orchestration/tx_executor_add_var.go
+++ b/txsystem/orchestration/tx_executor_add_var.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/txsystem/orchestration"
 	"github.com/alphabill-org/alphabill-go-base/types"
-	txtypes "github.com/alphabill-org/alphabill/txsystem/types"
-
 	"github.com/alphabill-org/alphabill/state"
 	"github.com/alphabill-org/alphabill/tree/avl"
+	txtypes "github.com/alphabill-org/alphabill/txsystem/types"
 )
 
 func (m *Module) executeAddVarTx(tx *types.TransactionOrder, attr *orchestration.AddVarAttributes, _ *orchestration.AddVarAuthProof, _ txtypes.ExecutionContext) (*types.ServerMetadata, error) {
@@ -31,7 +31,7 @@ func (m *Module) executeAddVarTx(tx *types.TransactionOrder, attr *orchestration
 	if err != nil {
 		return nil, fmt.Errorf("addVar: failed to update state: %w", err)
 	}
-	processingDetails, err := types.Cbor.Marshal(attr.Var)
+	processingDetails, err := cbor.Marshal(attr.Var)
 	if err != nil {
 		return nil, fmt.Errorf("addVar: failed to encode transaction processing result: %w", err)
 	}

--- a/txsystem/orchestration/tx_executor_add_var_test.go
+++ b/txsystem/orchestration/tx_executor_add_var_test.go
@@ -3,6 +3,7 @@ package orchestration
 import (
 	"testing"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/crypto"
 	abhash "github.com/alphabill-org/alphabill-go-base/hash"
 	"github.com/alphabill-org/alphabill-go-base/predicates/templates"
@@ -72,7 +73,7 @@ func TestAddVar_AddNewUnit_OK(t *testing.T) {
 	require.EqualValues(t, 0, unitData.EpochNumber)
 
 	// and tx processing result contains the validator assignment record from the tx
-	processingDetails, err := types.Cbor.Marshal(attr.Var)
+	processingDetails, err := cbor.Marshal(attr.Var)
 	require.NoError(t, err)
 	require.EqualValues(t, serverMetadata.ProcessingDetails, processingDetails)
 

--- a/txsystem/state_lock.go
+++ b/txsystem/state_lock.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	"github.com/alphabill-org/alphabill/logger"
 	"github.com/alphabill-org/alphabill/predicates"
@@ -127,7 +128,7 @@ func (m *GenericTxSystem) parseTxOnHold(unitID types.UnitID) (*types.Transaction
 	// unit has a state lock, any transaction with locked unit must first unlock
 	m.log.Debug("unit has a state lock", logger.UnitID(unitID))
 	txOnHold := &types.TransactionOrder{Version: 1}
-	if err = types.Cbor.Unmarshal(unit.StateLockTx(), txOnHold); err != nil {
+	if err = cbor.Unmarshal(unit.StateLockTx(), txOnHold); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal state lock transaction: %w", err)
 	}
 	return txOnHold, nil

--- a/txsystem/state_lock_test.go
+++ b/txsystem/state_lock_test.go
@@ -3,6 +3,7 @@ package txsystem
 import (
 	"testing"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	basetemplates "github.com/alphabill-org/alphabill-go-base/predicates/templates"
 	moneyid "github.com/alphabill-org/alphabill-go-base/testutils/money"
 	fcsdk "github.com/alphabill-org/alphabill-go-base/txsystem/fc"
@@ -268,7 +269,7 @@ func TestGenericTxSystem_handleUnlockUnitState(t *testing.T) {
 				RollbackPredicate:  basetemplates.NewP2pkh256BytesFromKey(pubKey1)},
 			),
 		)
-		txOnHoldBytes, err := types.Cbor.Marshal(txOnHold)
+		txOnHoldBytes, err := cbor.Marshal(txOnHold)
 		require.NoError(t, err)
 
 		// create mock tx system with unit(unitID, txOnHold) and dummy target units
@@ -359,7 +360,7 @@ func TestGenericTxSystem_handleUnlockUnitState(t *testing.T) {
 				RollbackPredicate:  basetemplates.NewP2pkh256BytesFromKey(pubKey1)},
 			),
 		)
-		txOnHoldBytes, err := types.Cbor.Marshal(txOnHold)
+		txOnHoldBytes, err := cbor.Marshal(txOnHold)
 		require.NoError(t, err)
 
 		// create mock tx system with unit(targetUnit1, txOnHold) and dummy target units
@@ -442,7 +443,7 @@ func TestGenericTxSystem_executeLockUnitState(t *testing.T) {
 			tt.WithAttributes(&money.TransferAttributes{}),
 			tt.WithStateLock(&types.StateLock{}),
 		)
-		txBytes, err := types.Cbor.Marshal(tx)
+		txBytes, err := cbor.Marshal(tx)
 		require.NoError(t, err)
 		execCtx := txtypes.NewExecutionContext(txSys, abfc.NewNoFeeCreditModule(), 10)
 		sm, err := txSys.executeLockUnitState(tx, txBytes, []types.UnitID{unitID}, execCtx)
@@ -460,7 +461,7 @@ func TestGenericTxSystem_executeLockUnitState(t *testing.T) {
 			tt.WithAttributes(&money.TransferAttributes{}),
 			tt.WithStateLock(&types.StateLock{ExecutionPredicate: []byte{1, 2, 3}}),
 		)
-		txBytes, err := types.Cbor.Marshal(tx)
+		txBytes, err := cbor.Marshal(tx)
 		require.NoError(t, err)
 		targetUnits := []types.UnitID{unitID}
 		execCtx := txtypes.NewExecutionContext(txSys, abfc.NewNoFeeCreditModule(), 10)
@@ -482,7 +483,7 @@ func TestGenericTxSystem_executeLockUnitState(t *testing.T) {
 				RollbackPredicate:  basetemplates.AlwaysTrueBytes(),
 			}),
 		)
-		txBytes, err := types.Cbor.Marshal(tx)
+		txBytes, err := cbor.Marshal(tx)
 		require.NoError(t, err)
 		targetUnits := []types.UnitID{unitID}
 		execCtx := txtypes.NewExecutionContext(txSys, abfc.NewNoFeeCreditModule(), 10)
@@ -521,7 +522,7 @@ func TestGenericTxSystem_executeLockUnitState(t *testing.T) {
 				RollbackPredicate:  basetemplates.AlwaysTrueBytes(),
 			}),
 		)
-		txBytes, err := types.Cbor.Marshal(tx)
+		txBytes, err := cbor.Marshal(tx)
 		require.NoError(t, err)
 		targetUnits := []types.UnitID{unitID}
 		idGen := money.PrndSh(tx)
@@ -568,7 +569,7 @@ func createLockTransaction(t *testing.T, id types.UnitID, pubkey []byte) []byte 
 		tt.WithStateLock(&types.StateLock{
 			ExecutionPredicate: basetemplates.NewP2pkh256BytesFromKey(pubkey)}),
 	)
-	txBytes, err := types.Cbor.Marshal(tx)
+	txBytes, err := cbor.Marshal(tx)
 	require.NoError(t, err)
 	return txBytes
 }

--- a/txsystem/testutils/transaction/transaction.go
+++ b/txsystem/testutils/transaction/transaction.go
@@ -3,6 +3,7 @@ package transaction
 import (
 	"testing"
 
+	"github.com/alphabill-org/alphabill-go-base/cbor"
 	"github.com/alphabill-org/alphabill-go-base/types"
 	test "github.com/alphabill-org/alphabill/internal/testutils"
 	"github.com/stretchr/testify/require"
@@ -68,7 +69,7 @@ func WithTransactionType(t uint16) Option {
 
 func WithAuthProof(authProof any) Option {
 	return func(tx *types.TransactionOrder) error {
-		authProofCBOR, err := types.Cbor.Marshal(authProof)
+		authProofCBOR, err := cbor.Marshal(authProof)
 		if err != nil {
 			return err
 		}
@@ -107,7 +108,7 @@ func WithStateLock(lock *types.StateLock) Option {
 
 func WithAttributes(attr any) Option {
 	return func(tx *types.TransactionOrder) error {
-		bytes, err := types.Cbor.Marshal(attr)
+		bytes, err := cbor.Marshal(attr)
 		if err != nil {
 			return err
 		}
@@ -116,7 +117,7 @@ func WithAttributes(attr any) Option {
 	}
 }
 
-func NewTransactionOrderBytes(t *testing.T, options ...Option) types.TaggedCBOR {
+func NewTransactionOrderBytes(t *testing.T, options ...Option) cbor.TaggedCBOR {
 	tx := NewTransactionOrder(t, options...)
 	txBytes, err := tx.MarshalCBOR()
 	require.NoError(t, err)
@@ -149,13 +150,13 @@ func NewTransactionRecord(t *testing.T, options ...Option) *types.TransactionRec
 	}
 }
 
-func TxoToBytes(t *testing.T, tx *types.TransactionOrder) types.TaggedCBOR {
+func TxoToBytes(t *testing.T, tx *types.TransactionOrder) cbor.TaggedCBOR {
 	txBytes, err := tx.MarshalCBOR()
 	require.NoError(t, err)
 	return txBytes
 }
 
-func TxoFromBytes(t *testing.T, txBytes types.TaggedCBOR) *types.TransactionOrder {
+func TxoFromBytes(t *testing.T, txBytes cbor.TaggedCBOR) *types.TransactionOrder {
 	tx := &types.TransactionOrder{Version: 1}
 	require.NoError(t, tx.UnmarshalCBOR(txBytes))
 	return tx


### PR DESCRIPTION
alphabill-go-base has CBOR support now in the separate package, upgrade dependency and fix usage.